### PR TITLE
Change the header link to quarkus.io as the app is deployed under status.quarkus.io

### DIFF
--- a/src/main/resources/templates/StatusResource/index.html
+++ b/src/main/resources/templates/StatusResource/index.html
@@ -9,7 +9,7 @@
 </head>
 <body>
 	<div class="ui fixed inverted menu">
-		<a class="header item" href="https://github.com/quarkusio/quarkus/pulls">
+		<a class="header item" href="https://quarkus.io">
 			<img class="logo" src="https://quarkus.io/assets/images/quarkus_logo_horizontal_rgb_reverse.svg" alt="Quarkus logo" style="width:200px;">
 		</a>
 		<span class="header item">


### PR DESCRIPTION
Change the header link to quarkus.io as the app is deployed under status.quarkus.io.

It feels more natural to get to parent/main address when I click on Quarkus logo.