### PR TITLE
Using pretty-time when displaying the status message

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,11 @@
             <artifactId>quarkus-openshift</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.ocpsoft.prettytime</groupId>
+            <artifactId>prettytime</artifactId>
+            <version>4.0.6.Final</version>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>

--- a/src/main/java/io/quarkus/status/StatusResource.java
+++ b/src/main/java/io/quarkus/status/StatusResource.java
@@ -2,7 +2,8 @@ package io.quarkus.status;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.ZoneId;
+import java.util.Date;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -14,6 +15,7 @@ import io.quarkus.qute.TemplateExtension;
 import io.quarkus.qute.TemplateInstance;
 import io.quarkus.qute.api.CheckedTemplate;
 import io.quarkus.status.model.Status;
+import org.ocpsoft.prettytime.PrettyTime;
 
 @Path("/")
 public class StatusResource {
@@ -35,10 +37,9 @@ public class StatusResource {
     @TemplateExtension
     static class Extensions {
 
-        private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd 'at' HH:mm:ss");
-
         static String formatDateTime(LocalDateTime dateTime) {
-            return FORMATTER.format(dateTime);
+            PrettyTime p = new PrettyTime();
+            return p.format(Date.from(dateTime.atZone(ZoneId.systemDefault()).toInstant()));
         }
     }
 }

--- a/src/main/java/io/quarkus/status/model/StatusLine.java
+++ b/src/main/java/io/quarkus/status/model/StatusLine.java
@@ -53,7 +53,7 @@ public class StatusLine implements Comparable<StatusLine> {
     @Override
     public int compareTo(StatusLine o) {
         if (order > -1 || o.order > -1) {
-            return order > o.order ? 1 : (order < o.order ? -1 : 0);
+            return Integer.compare(order, o.order);
         }
 
         return name.toLowerCase(Locale.ROOT).compareTo(o.name.toLowerCase(Locale.ROOT));

--- a/src/main/resources/templates/StatusResource/index.html
+++ b/src/main/resources/templates/StatusResource/index.html
@@ -32,7 +32,7 @@
 			<div class="ui icon message">
 				<i class="small sync icon"></i>
 				<div class="content">
-					<p>Updated on {status.updated.formatDateTime} (refreshed every 10 minutes).</p>
+					<p>Updated {status.updated.formatDateTime} (refreshed every 10 minutes).</p>
 				</div>
 			</div>
 			{#for section in status.sections}


### PR DESCRIPTION
Because showing the current date doesn't help if you're in a different timezone

![image](https://user-images.githubusercontent.com/54133/96035796-eb632480-0e39-11eb-98cf-0a95d40e20c8.png)
