### PR TITLE
Labels statistics for bugs and enhancements

### DIFF
--- a/src/main/java/io/quarkus/status/IssuesService.java
+++ b/src/main/java/io/quarkus/status/IssuesService.java
@@ -35,8 +35,8 @@ public class IssuesService {
 
     @Scheduled(every = "6H")
     public void updateStatus() throws IOException {
-        bugsStats = buildBugsMonthlyStats(BUG_NAME, BUG_LABEL);
-        enhancementsStats = buildBugsMonthlyStats(ENHANCEMENT_NAME, ENHANCEMENT_LABEL);
+        bugsStats = buildIssuesMonthlyStats(BUG_NAME, BUG_LABEL);
+        enhancementsStats = buildIssuesMonthlyStats(ENHANCEMENT_NAME, ENHANCEMENT_LABEL);
     }
 
     public Stats getBugsMonthlyStats() throws IOException {
@@ -45,7 +45,7 @@ public class IssuesService {
             synchronized (this) {
                 localStats = bugsStats;
                 if (localStats == null) {
-                    bugsStats = localStats = buildBugsMonthlyStats(BUG_NAME, BUG_LABEL);
+                    bugsStats = localStats = buildIssuesMonthlyStats(BUG_NAME, BUG_LABEL);
                 }
             }
         }
@@ -58,14 +58,14 @@ public class IssuesService {
             synchronized (this) {
                 localStats = enhancementsStats;
                 if (localStats == null) {
-                    enhancementsStats = localStats = buildBugsMonthlyStats(ENHANCEMENT_NAME, ENHANCEMENT_LABEL);
+                    enhancementsStats = localStats = buildIssuesMonthlyStats(ENHANCEMENT_NAME, ENHANCEMENT_LABEL);
                 }
             }
         }
         return localStats;
     }
 
-    private Stats buildBugsMonthlyStats(String name, String label) throws IOException {
+    private Stats buildIssuesMonthlyStats(String name, String label) throws IOException {
         Stats stats = new Stats();
         stats.name = name;
         stats.label = label;

--- a/src/main/java/io/quarkus/status/LabelsService.java
+++ b/src/main/java/io/quarkus/status/LabelsService.java
@@ -1,0 +1,66 @@
+package io.quarkus.status;
+
+import io.quarkus.scheduler.Scheduled;
+import io.quarkus.status.github.GitHubService;
+import io.quarkus.status.model.Label;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.List;
+
+@ApplicationScoped
+public class LabelsService {
+
+    private static final String QUARKUS_IO_ORG = "quarkusio";
+    private static final String MAIN_REPOSITORY = "quarkus";
+    public static final String BUG_LABEL = "kind/bug";
+    public static final String ENHANCEMENT_LABEL = "kind/enhancement";
+
+    @ConfigProperty(name = "status.labels.subset", defaultValue = "false")
+    boolean subsetOnly;
+
+    @Inject
+    GitHubService gitHubService;
+
+    private volatile List<Label> bugsLabels;
+    private volatile List<Label> enhancementsLabels;
+
+    @Scheduled(every = "6H")
+    public void updateStatus() throws IOException {
+        bugsLabels = buildLabelsStats(BUG_LABEL);
+        enhancementsLabels = buildLabelsStats(ENHANCEMENT_LABEL);
+    }
+
+    public List<Label> getBugsLabels() throws IOException {
+        List<Label> localLabels = bugsLabels;
+        if (localLabels == null) {
+            synchronized (this) {
+                localLabels = bugsLabels;
+                if (localLabels == null) {
+                    bugsLabels = localLabels = buildLabelsStats(BUG_LABEL);
+                }
+            }
+        }
+        return localLabels;
+    }
+
+    public List<Label> getEnhancementsLabels() throws IOException {
+        List<Label> localLabels = enhancementsLabels;
+        if (localLabels == null) {
+            synchronized (this) {
+                localLabels = enhancementsLabels;
+                if (localLabels == null) {
+                    enhancementsLabels = localLabels = buildLabelsStats(ENHANCEMENT_LABEL);
+                }
+            }
+        }
+        return localLabels;
+    }
+
+    private List<Label> buildLabelsStats(String mainLabel) throws IOException {
+        return gitHubService.labelsStats(QUARKUS_IO_ORG, MAIN_REPOSITORY, mainLabel, subsetOnly);
+    }
+
+}

--- a/src/main/java/io/quarkus/status/StatusResource.java
+++ b/src/main/java/io/quarkus/status/StatusResource.java
@@ -27,6 +27,9 @@ public class StatusResource {
     @Inject
     IssuesService issuesService;
 
+    @Inject
+    LabelsService labelsService;
+
     @CheckedTemplate
     public static class Templates {
         public static native TemplateInstance index(Status status);
@@ -51,6 +54,24 @@ public class StatusResource {
     @Produces(MediaType.TEXT_HTML)
     public TemplateInstance features() throws IOException {
         return Templates.issues(statusService.getStatus(), issuesService.getEnhancementsMonthlyStats(), false);
+    }
+
+    @GET
+    @Path("labels/bugs")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String bugsLabels() throws IOException {
+        StringBuilder sb = new StringBuilder();
+        labelsService.getBugsLabels().forEach( label -> sb.append(label).append("\n"));
+        return sb.toString();
+    }
+
+    @GET
+    @Path("labels/enhancements")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String enhancementsLabels() throws IOException {
+        StringBuilder sb = new StringBuilder();
+        labelsService.getEnhancementsLabels().forEach( label -> sb.append(label).append("\n"));
+        return sb.toString();
     }
 
     @TemplateExtension

--- a/src/main/java/io/quarkus/status/model/Label.java
+++ b/src/main/java/io/quarkus/status/model/Label.java
@@ -1,0 +1,21 @@
+package io.quarkus.status.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public class Label {
+    public String name;
+    public String open;
+    public String closed;
+
+    public Label(String name, String open, String closed) {
+        this.name = name;
+        this.open = open;
+        this.closed = closed;
+    }
+
+    @Override
+    public String toString() {
+        return name + "," + open + "," + closed;
+    }
+}

--- a/src/main/resources/META-INF/resources/js/csv_to_html_table.js
+++ b/src/main/resources/META-INF/resources/js/csv_to_html_table.js
@@ -1,0 +1,60 @@
+var CsvToHtmlTable = CsvToHtmlTable || {};
+
+CsvToHtmlTable = {
+    init: function (options) {
+        options = options || {};
+        var csv_path = options.csv_path || "";
+        var el = options.element || "table-container";
+        var allow_download = options.allow_download || false;
+        var csv_options = options.csv_options || {};
+        var datatables_options = options.datatables_options || {};
+        var custom_formatting = options.custom_formatting || [];
+        var customTemplates = {};
+        $.each(custom_formatting, function (i, v) {
+            var colIdx = v[0];
+            var func = v[1];
+            customTemplates[colIdx] = func;
+        });
+
+        var $table = $("<table class='ui celled striped table dataTable' id='" + el + "-table'></table>");
+        var $containerElement = $("#" + el);
+        $containerElement.empty().append($table);
+
+        $.when($.get(csv_path)).then(
+            function (data) {
+                var csvData = $.csv.toArrays(data, csv_options);
+                var $tableHead = $("<thead></thead>");
+                var csvHeaderRow = csvData[0];
+                var $tableHeadRow = $("<tr></tr>");
+                for (var headerIdx = 0; headerIdx < csvHeaderRow.length; headerIdx++) {
+                    $tableHeadRow.append($("<th></th>").text(csvHeaderRow[headerIdx]));
+                }
+                $tableHead.append($tableHeadRow);
+
+                $table.append($tableHead);
+                var $tableBody = $("<tbody></tbody>");
+
+                for (var rowIdx = 1; rowIdx < csvData.length; rowIdx++) {
+                    var $tableBodyRow = $("<tr></tr>");
+                    for (var colIdx = 0; colIdx < csvData[rowIdx].length; colIdx++) {
+                        var $tableBodyRowTd = $("<td></td>");
+                        var cellTemplateFunc = customTemplates[colIdx];
+                        if (cellTemplateFunc) {
+                            $tableBodyRowTd.html(cellTemplateFunc(csvData[rowIdx][colIdx]));
+                        } else {
+                            $tableBodyRowTd.text(csvData[rowIdx][colIdx]);
+                        }
+                        $tableBodyRow.append($tableBodyRowTd);
+                        $tableBody.append($tableBodyRow);
+                    }
+                }
+                $table.append($tableBody);
+
+                $table.DataTable(datatables_options);
+
+                if (allow_download) {
+                    $containerElement.append("<p><a class='btn btn-info' href='" + csv_path + "'><i class='glyphicon glyphicon-download'></i> Download as CSV</a></p>");
+                }
+            });
+    }
+};

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,4 @@ quarkus.openshift.annotations."kubernetes.io/tls-acme"=true
 quarkus.openshift.env.secrets=quarkus-status-token
 
 %dev.status.issues.stats.start=2020-09-01
+%dev.status.labels.subset=true

--- a/src/main/resources/templates/GitHubService/labelsStats.graphql
+++ b/src/main/resources/templates/GitHubService/labelsStats.graphql
@@ -1,0 +1,30 @@
+{
+  organization(login: "{owner}") {
+    repository(name: "{repo}") {
+      name
+      url
+      labels (first: {count}, {#if cursor}after: "{cursor}"{/if}) {
+        edges {
+          node {
+            name
+            open:issues(states: [OPEN], labels: ["{label}"]) {
+              totalCount
+            }
+            closed:issues(states: [CLOSED], labels: ["{label}"]) {
+              totalCount
+            }
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        totalCount
+      }
+    }
+  }
+  rateLimit {
+    cost
+    remaining
+  }
+}

--- a/src/main/resources/templates/StatusResource/issues.html
+++ b/src/main/resources/templates/StatusResource/issues.html
@@ -5,8 +5,14 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 	<title>Quarkus - {stats.name} Deep Dive</title>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.3/Chart.min.js"></script>
+	<script type="text/javascript" src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
+	<script type="text/javascript" src="https://cdn.datatables.net/1.10.22/js/jquery.dataTables.min.js"></script>
+	<script type="text/javascript" src="https://cdn.datatables.net/1.10.22/js/dataTables.semanticui.min.js"></script>
+	<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery-csv/1.0.11/jquery.csv.min.js"></script>
+	<script type="text/javascript" src="/js/csv_to_html_table.js"></script>
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/semantic.min.css" integrity="sha512-8bHTC73gkZ7rZ7vpqUQThUDhqcNFyYi2xgDgPDHc+GXVGHXq+xPjynxIopALmOPqzo9JZj0k6OqqewdGO3EsrQ==" crossorigin="anonymous" />
 	<link rel="stylesheet" href="/css/main.css" />
+	<link rel="stylesheet" href="https://cdn.datatables.net/1.10.22/css/dataTables.semanticui.min.css">
 	<link rel="shortcut icon" type="image/png" href="/favicon.ico" >
 </head>
 <body>
@@ -51,6 +57,8 @@
 			<div class="ui message">
 				<canvas id="canvas-lines"></canvas>
 			</div>
+
+			<div id='table-container'></div>
 		<script>
 			var barChartConfig = {
 				type: 'bar',
@@ -204,6 +212,21 @@
 				var ctxLines = document.getElementById('canvas-lines').getContext('2d');
 				window.lineChart = new Chart(ctxLines, lineChartConfig);
 			};
+
+			function format_link(link) {
+				if (link)
+					return "<a href='https://github.com/quarkusio/quarkus/issues?q=label:{stats.label}+label:\"" + link + "\"+is:issue+is:open' target='_blank'>" + link + "</a>";
+				else
+					return "";
+			}
+			CsvToHtmlTable.init({
+				csv_path: '/labels/{stats.name.toLowerCase}',
+				element: 'table-container',
+				allow_download: false,
+				csv_options: \{separator: ',', delimiter: '"'\},
+				datatables_options: \{"paging": false, "info": false, "order": [[ 1, 'desc' ], [ 2, 'desc' ]]\},
+				custom_formatting: [[0, format_link]]
+			});
 		</script>
 		</div>
 	</div>


### PR DESCRIPTION
Label statistics for bugs and enhancements

Introduced `/labels/bugs` and `/labels/enhancements` endpoints to produce labels stats for bugs and enhancements in csv format

issues.html enhanced with JS code to read csv data from endpoints and present them using DataTables (https://datatables.net/)

Bootstrap 4 and Semantic UI variant of the table are present in the PR (please checkout 9625c73 or 
3261c67). I like Bootstrap 4 variant more, Semantic UI is already used by quarkus-status so I prepared that variant too.

`csv_to_html_table.js` taken from https://github.com/derekeder/csv-to-html-table, csv-to-html-table is the main inspiration, but I didn't want to use the legacy bits from there.
